### PR TITLE
Add configurable scoring rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# VC Sourcing Agent
+
+This repository contains utilities for scoring startup opportunities.
+
+## Scoring configuration
+
+The scoring heuristic is controlled by the `config.yaml` file.  Each weight
+adjusts the score when certain signals are present:
+
+- `central_america_presence` – added when the startup lists a location in one of
+  Belize, Costa Rica, El Salvador, Guatemala, Honduras, Nicaragua or Panama.
+- `south_of_mexico_presence` – added when the location is in South America.
+- `fintech_keyword_penalty` – subtracted if the description contains fintech
+  terms such as "fintech", "banking" or "payments".
+- `female_founder_boost` – added when any founder is identified as female.
+
+Modify these weights in `config.yaml` to tune how opportunities are scored.

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,5 @@
+weights:
+  central_america_presence: 1.0
+  south_of_mexico_presence: 1.0
+  fintech_keyword_penalty: -1.0
+  female_founder_boost: 1.0

--- a/scoring.py
+++ b/scoring.py
@@ -1,0 +1,63 @@
+import yaml
+
+CENTRAL_AMERICA = {
+    'Belize', 'Costa Rica', 'El Salvador', 'Guatemala', 'Honduras', 'Nicaragua', 'Panama'
+}
+SOUTH_AMERICA = {
+    'Argentina', 'Bolivia', 'Brazil', 'Chile', 'Colombia', 'Ecuador', 'Guyana',
+    'Paraguay', 'Peru', 'Suriname', 'Uruguay', 'Venezuela'
+}
+FINTECH_KEYWORDS = {
+    'fintech', 'financial technology', 'banking', 'payments', 'lending',
+    'credit', 'debit', 'neobank'
+}
+
+
+def load_config(path: str = 'config.yaml') -> dict:
+    """Load YAML configuration from *path*."""
+    with open(path, 'r', encoding='utf-8') as fh:
+        return yaml.safe_load(fh)
+
+
+def score_startup(startup: dict, config: dict) -> float:
+    """Score a startup dictionary based on simple heuristics.
+
+    Parameters
+    ----------
+    startup:
+        Dictionary with optional keys ``location``, ``description`` and
+        ``founder_genders`` (list of strings).
+    config:
+        Configuration dictionary loaded from :func:`load_config`.
+    """
+    weights = config.get('weights', {})
+    score = 0.0
+
+    location = startup.get('location', '')
+    location_lower = location.lower()
+    if any(country.lower() in location_lower for country in CENTRAL_AMERICA):
+        score += weights.get('central_america_presence', 0)
+    elif any(country.lower() in location_lower for country in SOUTH_AMERICA):
+        score += weights.get('south_of_mexico_presence', 0)
+
+    description = startup.get('description', '')
+    description_lower = description.lower()
+    if any(keyword in description_lower for keyword in FINTECH_KEYWORDS):
+        score += weights.get('fintech_keyword_penalty', 0)
+
+    genders = startup.get('founder_genders', [])
+    genders_lower = [g.lower() for g in genders]
+    if any(g in {'female', 'woman', 'women'} for g in genders_lower):
+        score += weights.get('female_founder_boost', 0)
+
+    return score
+
+
+if __name__ == '__main__':
+    cfg = load_config()
+    demo_startup = {
+        'location': 'Costa Rica',
+        'description': 'A fintech platform empowering women-led businesses',
+        'founder_genders': ['female']
+    }
+    print('Demo score:', score_startup(demo_startup, cfg))


### PR DESCRIPTION
## Summary
- score startups higher for Central American and South American presence
- penalize fintech keywords and boost female-founder signals
- expose scoring weights in `config.yaml` and document them in the README

## Testing
- `python -m py_compile scoring.py`
- `python - <<'PY'
import yaml
from scoring import score_startup, load_config
cfg=load_config('config.yaml')
print('score',score_startup({'location':'Costa Rica','description':'Fintech platform','founder_genders':['female']}, cfg))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b3028a23a083339fc0ad9bcabcb4b4