### PR TITLE
Refactor scoring to use YAML config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,32 @@
+weights:
+  geo:
+    countries:
+      - Brazil
+      - Mexico
+      - Argentina
+      - Chile
+      - Colombia
+    weight: 3
+  post_revenue:
+    keywords:
+      - revenue
+      - profit
+      - annual recurring revenue
+      - ARR
+    weight: 3
+  female:
+    keywords:
+      - female
+      - woman
+      - women
+      - girl
+    weight: 2
+  enterprise:
+    keywords:
+      - enterprise
+      - b2b
+    weight: 1
+  fintech_penalty:
+    keywords:
+      - fintech
+    weight: -2

--- a/scoring.py
+++ b/scoring.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+import yaml
+from functools import lru_cache
+from typing import Any, Dict
+
+
+@lru_cache()
+def load_config(path: str = "config.yaml") -> Dict[str, Any]:
+    """Load YAML configuration for scoring."""
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+def score(country: str, text: str, config: Dict[str, Any] | None = None) -> int:
+    """Calculate lead score based on signals defined in config.
+
+    Args:
+        country: Country associated with the lead.
+        text: Text to search for signal keywords.
+        config: Optional pre-loaded configuration dictionary.
+
+    Returns:
+        Integer score clamped between 0 and 10.
+    """
+    if config is None:
+        config = load_config()
+    weights = config["weights"]
+    total = 0
+    text_lower = text.lower()
+    geo_conf = weights["geo"]
+    if country in geo_conf["countries"]:
+        total += geo_conf["weight"]
+    for key in ["post_revenue", "female", "enterprise", "fintech_penalty"]:
+        entry = weights[key]
+        if any(kw.lower() in text_lower for kw in entry["keywords"]):
+            total += entry["weight"]
+    return max(0, min(10, total))

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import scoring
+
+
+def test_geo_and_revenue():
+    text = "The company reported annual recurring revenue growth."
+    assert scoring.score("Brazil", text) == 6
+
+
+def test_female_and_fintech_penalty():
+    text = "A female-founded fintech launched in Mexico."
+    assert scoring.score("Mexico", text) == 3
+
+
+def test_enterprise_keyword():
+    text = "Argentina enterprise B2B startup reaches revenue milestones."
+    assert scoring.score("Argentina", text) == 7


### PR DESCRIPTION
## Summary
- Externalize scoring weights and keywords into `config.yaml`
- Refactor `score` function to load weights from config
- Add unit tests covering scoring scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b30909c89483339df82dcdfb676bf6