### PR TITLE
Improve lead filtering and review routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+data/new_rows.csv

--- a/config.yaml
+++ b/config.yaml
@@ -2,10 +2,70 @@ enable_cse: true
 cse_queries:
   - '(post-revenue OR "paying customers" OR ingresos OR facturación) (seed OR "pre-seed" OR ronda) (Costa Rica OR Guatemala OR El Salvador OR Honduras OR Nicaragua OR Panama OR Belize OR Colombia OR Venezuela OR Ecuador OR Peru OR Bolivia OR Chile OR Argentina OR Uruguay OR Paraguay OR Brazil)'
 feeds_extra:
-  - 'https://www.prnewswire.com/news-releases/news-releases-list/?rss=1&lang=es'   # example; swap for LATAM endpoints you want
-  - 'https://www.businesswire.com/portal/site/home/news/subject/?vnsId=31300&newsLang=es&rss=1' # example
-  - 'https://medium.com/feed/500-startups-latam'   # 500 LatAm
-  - 'https://startups.com/feed'                    # replace w/ Startupeable/Startups Latam feeds you pick
+  - 'https://www.prnewswire.com/news-releases/news-releases-list/?rss=1&lang=es'
+  - 'https://www.businesswire.com/portal/site/home/news/subject/?vnsId=31300&newsLang=es&rss=1'
+  - 'https://medium.com/feed/500-startups-latam'
+  - 'https://startups.com/feed'
+
+# Lists used by filters/scoring
+countries:
+  - Costa Rica
+  - Guatemala
+  - El Salvador
+  - Honduras
+  - Nicaragua
+  - Panama
+  - Belize
+  - Colombia
+  - Venezuela
+  - Ecuador
+  - Peru
+  - Bolivia
+  - Chile
+  - Argentina
+  - Uruguay
+  - Paraguay
+  - Brazil
+
+post_revenue_terms:
+  - post-revenue
+  - revenue
+  - facturación
+  - ingresos
+  - ARR
+  - MRR
+  - paying customers
+  - clientes de pago
+  - contrato
+  - invoices
+  - compras recurrentes
+
+enterprise_signal_terms:
+  - enterprise
+  - b2b
+  - corporativo
+  - contrato
+
+sector_blacklist_terms:
+  fintech:
+    - fintech
+    - bank
+    - banco
+    - pagos
+
+exclude_terms:
+  - pre-revenue
+  - idea
+  - hackathon
+  - university project
+  - seeking cofounder
+  - preincubation
+  - curso
+  - bootcamp
+
+min_score_to_append: 4
+min_score_to_review: 2
+
 weights:
   geo: 3
   post_revenue: 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ oauth2client==4.1.3
 python-dateutil==2.9.0
 pandas==2.2.2
 pyyaml==6.0.2
+
+rapidfuzz==3.5.2

--- a/src/dedupe.py
+++ b/src/dedupe.py
@@ -1,0 +1,74 @@
+"""Utilities to remove near-duplicate rows.
+
+The deduplication strategy is intentionally lightweight: it keeps the
+row with the highest ``score`` and most recent ``timestamp`` when either
+of the following conditions hold:
+
+* URLs match exactly.
+* ``company`` and ``title`` are very similar according to rapidfuzz's
+  token sort ratio (>=90).
+
+The module exposes a single :func:`dedupe_rows` function that accepts a
+list of dictionaries and returns a new list with duplicates removed.
+"""
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+try:  # pragma: no cover - best effort when rapidfuzz missing
+    from rapidfuzz import fuzz
+except Exception:  # pragma: no cover
+    class _Fallback:
+        @staticmethod
+        def token_sort_ratio(a: str, b: str) -> int:
+            return 100 if a == b else 0
+    fuzz = _Fallback()
+
+
+def _better(new: Dict, existing: Dict) -> bool:
+    """Return True if ``new`` should replace ``existing``."""
+    if new.get("score", 0) != existing.get("score", 0):
+        return new.get("score", 0) > existing.get("score", 0)
+    return new.get("timestamp", "") > existing.get("timestamp", "")
+
+
+def dedupe_rows(rows: Iterable[Dict], title_thresh: int = 90) -> List[Dict]:
+    """Merge near-duplicate entries.
+
+    Parameters
+    ----------
+    rows:
+        Iterable of dictionaries representing leads.
+    title_thresh:
+        Similarity threshold for matching titles/companies.  Defaults to
+        90 which is conservative but effective for noisy data.
+    """
+
+    deduped: List[Dict] = []
+    for row in rows:
+        row_url = row.get("url")
+        row_title = (row.get("title") or "").lower()
+        row_company = (row.get("company") or "").lower()
+
+        replacement_idx = None
+        for idx, existing in enumerate(deduped):
+            ex_url = existing.get("url")
+            if row_url and ex_url and row_url == ex_url:
+                replacement_idx = idx
+                break
+
+            ex_title = (existing.get("title") or "").lower()
+            ex_company = (existing.get("company") or "").lower()
+            if (
+                fuzz.token_sort_ratio(row_title, ex_title) >= title_thresh
+                and fuzz.token_sort_ratio(row_company, ex_company) >= title_thresh
+            ):
+                replacement_idx = idx
+                break
+
+        if replacement_idx is None:
+            deduped.append(row)
+        elif _better(row, deduped[replacement_idx]):
+            deduped[replacement_idx] = row
+
+    return deduped

--- a/src/filters.py
+++ b/src/filters.py
@@ -1,0 +1,71 @@
+"""Filtering utilities for sourcing leads.
+
+This module contains small helper functions used to check whether
+content includes required signals such as post‑revenue indicators or
+country mentions. All checks are case insensitive and operate on plain
+strings.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+
+def _normalize(text: str) -> str:
+    """Return ``text`` in lower case or an empty string if ``None``."""
+    return text.lower() if isinstance(text, str) else ""
+
+
+def must_have_any(text: str, terms: Sequence[str]) -> bool:
+    """Return ``True`` if *any* term is found within ``text``.
+
+    Parameters
+    ----------
+    text:
+        Text to search. ``None`` is treated as an empty string.
+    terms:
+        Iterable of phrases that should trigger a positive match.
+    """
+
+    lower = _normalize(text)
+    return any(t.lower() in lower for t in terms)
+
+
+def must_have_geo(parts: Iterable[str], countries: Sequence[str]) -> bool:
+    """Return ``True`` if any country is mentioned in the given text parts.
+
+    ``parts`` is typically an iterable with the title, snippet and url of a
+    search result. ``None`` values are ignored.
+    """
+
+    combined = " ".join(_normalize(p) for p in parts if p)
+    return any(country.lower() in combined for country in countries)
+
+
+def exclude_if_any(text: str, terms: Sequence[str]) -> bool:
+    """Return ``True`` if any of the terms appear in ``text``.
+
+    This helper is used to drop rows that contain noisy phrases such as
+    "pre‑revenue" or "hackathon".
+    """
+
+    lower = _normalize(text)
+    return any(term.lower() in lower for term in terms)
+
+
+def sector_penalty(text: str, sector_terms: dict[str, Sequence[str]],
+                   weights: dict[str, int]) -> int:
+    """Return a negative penalty if text matches a black‑listed sector.
+
+    At the moment the only supported sector is ``fintech``.  The penalty
+    value is retrieved from ``weights['fintech_penalty']`` so that the
+    configuration file controls its magnitude.
+    """
+
+    lower = _normalize(text)
+    penalty = 0
+
+    fintech_terms = sector_terms.get("fintech", [])
+    if any(t.lower() in lower for t in fintech_terms):
+        penalty += weights.get("fintech_penalty", 0)
+
+    return penalty

--- a/src/sourcing.py
+++ b/src/sourcing.py
@@ -1,0 +1,115 @@
+"""Scoring and routing of potential leads.
+
+The module exposes helpers that take a list of candidate rows and decide
+whether they should be appended to the main ``Leads`` worksheet, routed
+to a ``Review`` worksheet, or discarded.
+
+Only configuration loading and pure-Python logic live here so the module
+is easily testable; interactions with external services (Google Sheets,
+feeds, etc.) remain elsewhere in the project.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+import pandas as pd
+import yaml
+
+from . import dedupe, filters
+
+
+@dataclass
+class Row:
+    title: str
+    snippet: str
+    url: str
+    company: str | None = None
+    timestamp: str | None = None
+    score: int | None = None
+
+
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.yaml"
+
+
+def load_config(path: str | Path = DEFAULT_CONFIG_PATH) -> Dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def score_row(row: Row, config: Dict) -> Tuple[int, bool, bool, bool, int]:
+    """Return a tuple with the score and individual feature flags.
+
+    Returns ``(score, postrev, geo, enterprise, penalty)``.
+    """
+
+    text_parts = [row.title, row.snippet, row.url]
+    combined_text = " ".join(p for p in text_parts if p)
+
+    postrev = filters.must_have_any(combined_text, config.get("post_revenue_terms", []))
+    geo = filters.must_have_geo(text_parts, config.get("countries", []))
+    enterprise = filters.must_have_any(combined_text, config.get("enterprise_signal_terms", []))
+    penalty = filters.sector_penalty(combined_text, config.get("sector_blacklist_terms", {}), config.get("weights", {}))
+
+    weights = config.get("weights", {})
+    score = (
+        geo * weights.get("geo", 0)
+        + postrev * weights.get("post_revenue", 0)
+        + enterprise * weights.get("enterprise", 0)
+        + penalty
+    )
+    return score, postrev, geo, enterprise, penalty
+
+
+def classify_row(row: Row, config: Dict) -> str:
+    score, postrev, geo, enterprise, penalty = score_row(row, config)
+    row.score = score
+
+    if filters.exclude_if_any(
+        f"{row.title} {row.snippet}", config.get("exclude_terms", [])
+    ):
+        return "drop"
+
+    min_append = config.get("min_score_to_append", 4)
+    min_review = config.get("min_score_to_review", 2)
+
+    # Require both a post-revenue indicator and a geo signal to make it
+    # directly into Leads. Otherwise route to Review if score is high
+    # enough, drop otherwise.
+    if postrev and geo and score >= min_append:
+        return "lead"
+    if score >= min_review:
+        return "review"
+    return "drop"
+
+
+def process_rows(rows: Iterable[Dict], config: Dict) -> Tuple[List[Dict], List[Dict]]:
+    """Score, dedupe and route ``rows`` according to ``config``.
+
+    ``rows`` should be an iterable of dictionaries with at least ``title``,
+    ``snippet`` and ``url`` keys.  The function returns ``(leads, review)``
+    lists.  If any leads are appended, they are also written to
+    ``data/new_rows.csv`` for downstream processing.
+    """
+
+    row_objs = [Row(**r) for r in rows]
+    for row in row_objs:
+        row.classification = classify_row(row, config)
+
+    deduped = dedupe.dedupe_rows([r.__dict__ for r in row_objs])
+
+    leads: List[Dict] = []
+    review: List[Dict] = []
+    for row in deduped:
+        cls = row.get("classification")
+        if cls == "lead":
+            leads.append(row)
+        elif cls == "review":
+            review.append(row)
+
+    if leads:
+        Path("data").mkdir(exist_ok=True)
+        pd.DataFrame(leads).to_csv("data/new_rows.csv", index=False)
+
+    return leads, review

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+# Ensure the package root is importable when using the src layout
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.sourcing import Row, classify_row, load_config
+
+CONFIG = load_config(ROOT / "config.yaml")
+
+
+def test_lead_routing():
+    row = Row(title="Startup post-revenue in Chile", snippet="", url="http://example.com")
+    assert classify_row(row, CONFIG) == "lead"
+    assert row.score >= 4
+
+
+def test_review_missing_geo():
+    row = Row(title="Post-revenue startup expanding", snippet="", url="http://example.com")
+    assert classify_row(row, CONFIG) == "review"
+
+
+def test_review_missing_postrevenue():
+    row = Row(title="Startup in Chile raises seed", snippet="", url="http://example.com")
+    assert classify_row(row, CONFIG) == "review"
+
+
+def test_excluded_term_drop():
+    row = Row(title="Idea stage project in Chile", snippet="", url="http://example.com")
+    assert classify_row(row, CONFIG) == "drop"
+
+
+def test_fintech_penalty():
+    row = Row(title="Fintech post-revenue in Brazil", snippet="", url="http://example.com")
+    classification = classify_row(row, CONFIG)
+    assert classification == "lead"
+    assert row.score == 4


### PR DESCRIPTION
## Summary
- add configurable filters for post-revenue, geography and exclusion terms
- score leads and route to Leads vs Review sheets with sector penalties
- deduplicate near-duplicate entries and persist newly added rows
- document pipeline through unit tests

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement rapidfuzz==3.5.2)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6364fded0833396f971f84c2f3efa