### PR TITLE
Add filter-based scoring and dedupe with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+data/
+__pycache__/
+*.pyc

--- a/config.yaml
+++ b/config.yaml
@@ -1,11 +1,53 @@
 enable_cse: true
 cse_queries:
-  - '(post-revenue OR "paying customers" OR ingresos OR facturación) (seed OR "pre-seed" OR ronda) (Costa Rica OR Guatemala OR El Salvador OR Honduras OR Nicaragua OR Panama OR Belize OR Colombia OR Venezuela OR Ecuador OR Peru OR Bolivia OR Chile OR Argentina OR Uruguay OR Paraguay OR Brazil)'
+  - '(post-revenue OR "paying customers" OR ingresos OR facturación) (seed OR "pre-seed" OR ronda) (Costa Rica OR Guatemala OR El Salvador OR Honduras OR Nicaragua OR Panama OR Belize OR Colombia OR Venezuela OR Ecuador OR Peru OR Bolivia OR Chile OR Argentina OR Uruguay OR Paraguay OR Brazil OR Mexico)'
 feeds_extra:
-  - 'https://www.prnewswire.com/news-releases/news-releases-list/?rss=1&lang=es'   # example; swap for LATAM endpoints you want
-  - 'https://www.businesswire.com/portal/site/home/news/subject/?vnsId=31300&newsLang=es&rss=1' # example
-  - 'https://medium.com/feed/500-startups-latam'   # 500 LatAm
-  - 'https://startups.com/feed'                    # replace w/ Startupeable/Startups Latam feeds you pick
+  - 'https://www.prnewswire.com/news-releases/news-releases-list/?rss=1&lang=es'
+  - 'https://www.businesswire.com/portal/site/home/news/subject/?vnsId=31300&newsLang=es&rss=1'
+  - 'https://medium.com/feed/500-startups-latam'
+  - 'https://startups.com/feed'
+min_score_to_append: 4
+min_score_to_review: 2
+dedupe_min_ratio: 86
+dedupe_fields: ["Company", "Title"]
+exclude_terms:
+  - pre-revenue
+  - idea
+  - hackathon
+  - seeking cofounder
+  - curso
+  - bootcamp
+  - incubadora estudiantil
+must_have_any:
+  - revenue
+  - ingresos
+  - facturación
+  - paying customers
+must_have_geo:
+  - costa rica
+  - guatemala
+  - el salvador
+  - honduras
+  - nicaragua
+  - panama
+  - belize
+  - colombia
+  - venezuela
+  - ecuador
+  - peru
+  - bolivia
+  - chile
+  - argentina
+  - uruguay
+  - paraguay
+  - brazil
+  - mexico
+enterprise_bonus:
+  - enterprise
+  - b2b
+fintech_penalty:
+  - fintech
+  - payments
 weights:
   geo: 3
   post_revenue: 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ oauth2client==4.1.3
 python-dateutil==2.9.0
 pandas==2.2.2
 pyyaml==6.0.2
+rapidfuzz>=3.0,<4.0
+pytest>=7.0

--- a/src/dedupe.py
+++ b/src/dedupe.py
@@ -1,0 +1,64 @@
+"""Deduplication utilities."""
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import pandas as pd
+
+try:
+    from rapidfuzz import fuzz
+
+    def _ratio(a: str, b: str) -> float:
+        return fuzz.token_set_ratio(a, b)
+except Exception:  # pragma: no cover - fallback
+    from difflib import SequenceMatcher
+
+    def _ratio(a: str, b: str) -> float:  # pragma: no cover - fallback
+        return SequenceMatcher(None, a, b).ratio() * 100
+
+
+def cluster_and_keep_top(
+    df: pd.DataFrame,
+    keys: List[str] | None = None,
+    url_col: str = "URL",
+    score_col: str = "Score",
+    date_col: str = "Date",
+    min_ratio: float = 86.0,
+) -> Tuple[pd.DataFrame, int, int, int]:
+    """Drop exact URL duplicates and cluster near-duplicates.
+
+    Returns the deduped dataframe along with before/after counts and number of
+    clusters formed. Rows keep their assigned ``cluster_id``.
+    """
+    if keys is None:
+        keys = ["Company", "Title"]
+
+    df = df.copy()
+    before = len(df)
+
+    # remove exact URL duplicates keeping highest score then newest
+    df = df.sort_values(by=[score_col, date_col], ascending=[False, False])
+    df = df.drop_duplicates(subset=[url_col], keep="first")
+
+    combined = (
+        df[keys].fillna("").agg(" ".join, axis=1).str.lower().tolist()
+    )
+
+    clusters: List[str] = []
+    cluster_ids: List[int] = []
+
+    for text in combined:
+        assigned = False
+        for idx, rep in enumerate(clusters):
+            if _ratio(text, rep) >= min_ratio:
+                cluster_ids.append(idx)
+                assigned = True
+                break
+        if not assigned:
+            clusters.append(text)
+            cluster_ids.append(len(clusters) - 1)
+
+    df["cluster_id"] = cluster_ids
+    deduped = df.drop_duplicates(subset=["cluster_id"], keep="first")
+    after = len(deduped)
+    return deduped, before, after, len(clusters)

--- a/src/filters.py
+++ b/src/filters.py
@@ -1,0 +1,54 @@
+"""Filtering and scoring utilities for sourcing."""
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+import yaml
+
+
+def load_config(path: str = "config.yaml") -> Dict:
+    """Load YAML configuration from *path*."""
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def score_row(row: Dict, config: Dict) -> Tuple[int, str]:
+    """Apply rule checks to a row and return (score, reason_codes)."""
+    text = f"{row.get('Title', '')} {row.get('Snippet', '')}".lower()
+    country = str(row.get("Country", "")).lower()
+    weights = config.get("weights", {})
+
+    score = 0
+    codes = []
+
+    # exclusion terms are hard filters
+    if any(term.lower() in text for term in config.get("exclude_terms", [])):
+        codes.append("exclude")
+        return 0, ",".join(codes)
+
+    if country in (c.lower() for c in config.get("must_have_geo", [])):
+        score += weights.get("geo", 0)
+        codes.append("geo")
+
+    if any(term.lower() in text for term in config.get("must_have_any", [])):
+        score += weights.get("post_revenue", 0)
+        codes.append("post_revenue")
+
+    if any(term.lower() in text for term in config.get("enterprise_bonus", [])):
+        score += weights.get("enterprise", 0)
+        codes.append("enterprise")
+
+    if any(term.lower() in text for term in config.get("fintech_penalty", [])):
+        score += weights.get("fintech_penalty", 0)
+        codes.append("fintech_penalty")
+
+    return score, ",".join(codes)
+
+
+def apply_filters(df, config: Dict):
+    """Apply filters to a dataframe and add Score and Reason Codes columns."""
+    results = df.apply(lambda row: score_row(row, config), axis=1, result_type="expand")
+    df = df.copy()
+    df["Score"] = results[0]
+    df["Reason Codes"] = results[1]
+    return df

--- a/src/sourcing.py
+++ b/src/sourcing.py
@@ -1,0 +1,59 @@
+"""Main sourcing utilities."""
+from __future__ import annotations
+
+import os
+from typing import Dict, Tuple
+
+import pandas as pd
+import yaml
+
+from .filters import apply_filters
+from .dedupe import cluster_and_keep_top
+
+
+COLUMNS = [
+    "Company",
+    "URL",
+    "Source",
+    "Country",
+    "Title",
+    "Snippet",
+    "Signals",
+    "Score",
+    "Reason Codes",
+    "Date",
+    "Run ID",
+]
+
+
+def route(df: pd.DataFrame, config: Dict | None = None, config_path: str = "config.yaml") -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Score, dedupe and route rows to Leads or Review."""
+    if config is None:
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+
+    df = apply_filters(df, config)
+
+    dedupe_fields = config.get("dedupe_fields", ["Company", "Title"])
+    min_ratio = config.get("dedupe_min_ratio", 86)
+    deduped, before, after, clusters = cluster_and_keep_top(
+        df,
+        keys=dedupe_fields,
+        min_ratio=min_ratio,
+    )
+    print(f"[dedupe] kept {after}/{before}; clusters={clusters}")
+
+    min_append = config.get("min_score_to_append", 4)
+    min_review = config.get("min_score_to_review", 2)
+
+    leads = deduped[deduped["Score"] >= min_append]
+    review = deduped[(deduped["Score"] >= min_review) & (deduped["Score"] < min_append)]
+
+    leads = leads[COLUMNS]
+    review = review[COLUMNS]
+
+    if not leads.empty:
+        os.makedirs("data", exist_ok=True)
+        leads.to_csv("data/new_rows.csv", index=False)
+
+    return leads, review

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -1,0 +1,34 @@
+import sys
+import os
+import pandas as pd
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from src.dedupe import cluster_and_keep_top
+
+
+def test_cluster_and_keep_top():
+    df = pd.DataFrame([
+        {
+            'Company': 'Acme',
+            'Title': 'Acme raises seed round',
+            'URL': 'http://a1',
+            'Score': 5,
+            'Date': '2024-01-02',
+        },
+        {
+            'Company': 'Acme',
+            'Title': 'Acme raises seed funding',
+            'URL': 'http://a2',
+            'Score': 3,
+            'Date': '2024-01-01',
+        },
+    ])
+
+    deduped, before, after, clusters = cluster_and_keep_top(df, min_ratio=86)
+
+    assert before == 2
+    assert after == 1
+    assert clusters == 1
+    row = deduped.iloc[0]
+    assert row['URL'] == 'http://a1'
+    assert row['cluster_id'] == 0

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import pandas as pd
+import yaml
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from src.sourcing import route
+
+
+def test_routing(tmp_path):
+    config = yaml.safe_load(open('config.yaml'))
+    df = pd.DataFrame([
+        {
+            'Company': 'Acme',
+            'URL': 'http://a',
+            'Source': 'feed',
+            'Country': 'mexico',
+            'Title': 'Acme hits $1M revenue',
+            'Snippet': 'company with strong revenue growth',
+            'Signals': '',
+            'Date': '2024-01-01',
+            'Run ID': '1',
+        },
+        {
+            'Company': 'Beta',
+            'URL': 'http://b',
+            'Source': 'feed',
+            'Country': 'mexico',
+            'Title': 'Beta launches new product',
+            'Snippet': 'launch in mexico',
+            'Signals': '',
+            'Date': '2024-01-01',
+            'Run ID': '1',
+        },
+        {
+            'Company': 'Gamma',
+            'URL': 'http://c',
+            'Source': 'feed',
+            'Country': 'mexico',
+            'Title': 'Gamma pre-revenue idea',
+            'Snippet': 'pre-revenue hackathon project',
+            'Signals': '',
+            'Date': '2024-01-01',
+            'Run ID': '1',
+        },
+    ])
+
+    leads, review = route(df, config=config)
+
+    assert leads['Company'].tolist() == ['Acme']
+    assert review['Company'].tolist() == ['Beta']
+
+    assert os.path.exists('data/new_rows.csv')
+    new_rows = pd.read_csv('data/new_rows.csv')
+    assert new_rows['Company'].tolist() == ['Acme']
+    # cleanup
+    os.remove('data/new_rows.csv')


### PR DESCRIPTION
## Summary
- Add config-driven filters to score leads and emit reason codes
- Introduce clustering deduper with RapidFuzz fallback
- Route scored rows to Leads or Review and persist new rows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf55eac7508333bcfe3ed2e0148ca6